### PR TITLE
データテーブルでポインターが指のマークになるのは概要の列だけにする

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -9,7 +9,7 @@
 .v-main {
     margin-bottom: 30px;
 }
-.v-data-table {
+.div__text-link {
     cursor: pointer;
 }
 .img__title {

--- a/app/javascript/components/MarksPage.vue
+++ b/app/javascript/components/MarksPage.vue
@@ -46,7 +46,7 @@
               <span class="span__avatar-text">{{ item.name }}</span>
             </template>
             <template #[`item.text`]="{ item }">
-              <div @click="editClick(item)">
+              <div @click="editClick(item)" class="div__text-link">
                 {{
                   item.text.slice(0, 50) + (item.text.length > 50 ? '...' : '')
                 }}


### PR DESCRIPTION
ref #125