### PR TITLE
長いURLや英単語が折り返えさないのを修正

### DIFF
--- a/app/javascript/components/MarksPage.vue
+++ b/app/javascript/components/MarksPage.vue
@@ -198,3 +198,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.v-data-table {
+  word-break: break-all;
+}
+</style>


### PR DESCRIPTION
- 正常な表示
![image](https://user-images.githubusercontent.com/73627898/153578478-ffd2c0fd-36ca-45d7-b238-c25991eb6830.png)

- 誤った表示
![image](https://user-images.githubusercontent.com/73627898/153578553-72158c70-c420-4eb5-ad0f-f5eaa3351350.png)
